### PR TITLE
Use filter codes instead of filter names

### DIFF
--- a/lib/Client.ts
+++ b/lib/Client.ts
@@ -41,7 +41,8 @@ export class Client {
     let filterStatuses = response.body.filterList.map(filter => {
       let filterStatus: FilterStatus = {
         name: filter.filterName,
-        lifeLevel: filter.filterPer
+        lifeLevel: filter.filterPer,
+        code: filter.filterCode
       }
 
       return filterStatus;

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -34,7 +34,7 @@ export namespace Config {
   }
 
   export namespace Filters {
-    export const PRE_FILTER = 'Pre Filter';
-    export const MAIN_FILTER = 'Max2 Filter';
+    export const PRE_FILTER = '3121332';
+    export const MAIN_FILTER = '3111735';
   }
 }

--- a/lib/interfaces/PurifierStatus.ts
+++ b/lib/interfaces/PurifierStatus.ts
@@ -39,6 +39,7 @@ export interface Status {
 export interface FilterStatus {
   name: string
   lifeLevel: number
+  code: string
 }
 
 export interface Metadata {

--- a/lib/services/FilterService.ts
+++ b/lib/services/FilterService.ts
@@ -78,10 +78,10 @@ export class FilterService extends AbstractService {
     }
   }
 
-  async getChangeIndicationForFilter(name: string): Promise<any> {
+  async getChangeIndicationForFilter(code: string): Promise<any> {
     try {
       let status = await this.purifier.waitForFilterStatusUpdate();
-      let statusForFilter = status.find(filter => filter.name == name);
+      let statusForFilter = status.find(filter => filter.code == code);
       let indication;
 
       if (statusForFilter.lifeLevel <= 20) {
@@ -92,19 +92,19 @@ export class FilterService extends AbstractService {
 
       return indication;
     } catch(e) {
-      Logger.error(`Unable to get filter change indication for ${name}`, e);
+      Logger.error(`Unable to get filter change indication for ${code}`, e);
       throw e;
     }
   }
 
-  async getLifeLevelForFilter(name: string): Promise<number> {
+  async getLifeLevelForFilter(code: string): Promise<number> {
     try {
       let status = await this.purifier.waitForFilterStatusUpdate();
-      let statusForFilter = status.find(filter => filter.name == name);
+      let statusForFilter = status.find(filter => filter.code == code);
 
       return statusForFilter.lifeLevel;
     } catch(e) {
-      Logger.error(`Unable to get filter life level for ${name}`, e);
+      Logger.error(`Unable to get filter life level for ${code}`, e);
       throw e;
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "homebridge-airmega",
-	"version": "3.1.9",
+	"version": "3.1.10",
 	"description": "Homebridge plugin for the Airmega air purifier",
 	"main": "./dist/index.js",
 	"author": "Andrew Schaper",
@@ -24,7 +24,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/aschzero/homebridge-airmega"
+		"url": "https://github.com/shamanskyh/homebridge-airmega"
 	},
 	"keywords": [
 		"coway",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "homebridge-airmega",
+	"name": "homebridge-airmega-shamanskyh",
 	"version": "3.1.10",
 	"description": "Homebridge plugin for the Airmega air purifier",
 	"main": "./dist/index.js",


### PR DESCRIPTION
Hey, thanks for writing this great plugin! I noticed that I would get errors in Homebridge when the filter status was requested, and after some debugging, I see that I'm getting Korean names returned for the two filters (`극세사망 프리필터` and `Max2 필터`). My app appears in English, though, and I don't see any way to change my language settings, so I thought it might be a little bit more defensive to refer to filters by their "codes" rather than their names. The pre-filter has code `3121332` and the main filter has code `3111735`.

This PR assumes the codes are stable across devices. Please let me know if you have any feedback, and again, thank you for putting this together!